### PR TITLE
support wrapping months

### DIFF
--- a/later.js
+++ b/later.js
@@ -926,15 +926,25 @@ later = function() {
       return clone;
     }
     function add(sched, name, min, max, inc) {
-      var i = min;
       if (!sched[name]) {
         sched[name] = [];
       }
-      while (i <= max) {
-        if (sched[name].indexOf(i) < 0) {
-          sched[name].push(i);
+      var loopTo = function(start, max){
+        var i = start;
+        while ( i <= max ){
+          if (sched[name].indexOf(i) < 0) {
+            sched[name].push(i);
+          }
+          i += inc || 1;
         }
-        i += inc || 1;
+      }
+      if ( min > max ){
+        var field = FIELDS[name];
+        loopTo(min, field[2]);
+        loopTo(field[1], max);
+      }
+      else{
+        loopTo(min, max);
       }
     }
     function addHash(schedules, curSched, value, hash) {

--- a/src/parse/cron.js
+++ b/src/parse/cron.js
@@ -79,17 +79,33 @@ later.parse.cron = function (expr, hasSeconds) {
   * @param {Int} inc: The increment to use between min and max
   */
   function add(sched, name, min, max, inc) {
-    var i = min;
-
     if (!sched[name]) {
       sched[name] = [];
     }
 
-    while (i <= max) {
-      if (sched[name].indexOf(i) < 0) {
-        sched[name].push(i);
+    var loopTo = function(start, max){
+      var i = start;
+
+      while ( i <= max ){
+        if (sched[name].indexOf(i) < 0) {
+          sched[name].push(i);
+        }
+        i += inc || 1;
       }
-      i += inc || 1;
+    }
+
+    // if the min is greater than the max, loop it
+    if ( min > max ){
+      var field = FIELDS[name];
+
+      // add up to the max value
+      loopTo(min, field[2]);
+
+      // loop it over
+      loopTo(field[1], max);
+    }
+    else{
+      loopTo(min, max);
     }
   }
 

--- a/test/parse/cron-test.js
+++ b/test/parse/cron-test.js
@@ -262,6 +262,11 @@ describe('Parse Cron', function() {
 			p.schedules[0].should.eql({M: [1,3,5]});
 		});
 
+		it('should parse a wrapped range value', function() {
+			var p = parse('* * * * 11-2 *', true);
+			p.schedules[0].should.eql({M: [11,12,1,2]});
+		});
+
 	});
 
 	describe('day of week', function() {


### PR DESCRIPTION
fixes #48
if max is less than the min, it'll loop twice.  first to the end of the range from min, and than from the low end of the range to max.

I wasn't sure how you were generating the code, so i just modified the later.js directly.  not sure if that's correct.