### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "later",
+  "version": "1.1.6",
+  "description": "Determine later (or previous) occurrences of recurring schedules",
+  "keywords": [
+    "schedule",
+    "occurrences",
+    "recur",
+    "cron"
+  ],
+  "authors": ["BunKat <bill@bunkat.com>"],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/bunkat/later.git"
+  },
+  "main": "index.js",
+  "license": "MIT"
+}


### PR DESCRIPTION
`later` has become useful on a piece of client-side code, it would be nice to be able to fetch it through bower with the version information intact.