### PR TITLE
Remove broken links to Diagram Generator

### DIFF
--- a/parsers.html
+++ b/parsers.html
@@ -398,7 +398,7 @@
             <code>exception</code> keyword starts an exception schedule.</p>
           <img src='./assets/img/Composite.png'>
           <br/>
-          <small>Railroad diagram created using <a href="http://railroad.my28msec.com/rr/ui">Railroad Diagram Generator</a>.</small>
+          <small>Railroad diagram created using Railroad Diagram Generator.</small>
           <br/>
           <br/>
 
@@ -437,7 +437,7 @@
 
           <img src='./assets/img/Schedule.png'>
           <br/>
-          <small>Railroad diagram created using <a href="http://railroad.my28msec.com/rr/ui">Railroad Diagram Generator</a>.</small>
+          <small>Railroad diagram created using Railroad Diagram Generator.</small>
           <br/>
           <br/>
 
@@ -480,7 +480,7 @@
             constraint.</p>
           <img src='./assets/img/Range.png'>
           <br/>
-          <small>Railroad diagram created using <a href="http://railroad.my28msec.com/rr/ui">Railroad Diagram Generator</a>.</small>
+          <small>Railroad diagram created using Railroad Diagram Generator.</small>
           <br/>
           <br/>
 


### PR DESCRIPTION
Links for Railsroads Diagram Generator are broken, this update removes broken links.