### PR TITLE
cron value 7 for day-of-week should be parsed as SUN instead of SAT

### DIFF
--- a/later.js
+++ b/later.js
@@ -949,8 +949,11 @@ later = function() {
       Y: [ 6, 1970, 2099 ],
       d: [ 5, 1, 7, 1 ]
     };
-    function getValue(value, offset, max) {
-      return isNaN(value) ? NAMES[value] || null : Math.min(+value + (offset || 0), max || 9999);
+    function getValue(value, offset, min, max) {
+      offset = offset || 0;
+      min = min || 0;
+      max = max || 9999;
+      return isNaN(value) ? NAMES[value] || null : (+value + offset - min) % (max + 1 - min) + min;
     }
     function cloneSchedule(sched) {
       var clone = {}, field;
@@ -1008,8 +1011,8 @@ later = function() {
       var incSplit = item.split("/"), inc = +incSplit[1], range = incSplit[0];
       if (range !== "*" && range !== "0") {
         var rangeSplit = range.split("-");
-        min = getValue(rangeSplit[0], offset, max);
-        max = getValue(rangeSplit[1], offset, max) || max;
+        min = getValue(rangeSplit[0], offset, min, max);
+        max = getValue(rangeSplit[1], offset, min, max) || max;
       }
       add(curSched, name, min, max, inc);
     }
@@ -1018,14 +1021,14 @@ later = function() {
       if (item === "L") {
         item = min - 1;
       }
-      if ((value = getValue(item, offset, max)) !== null) {
+      if ((value = getValue(item, offset, min, max)) !== null) {
         add(curSched, name, value, value);
-      } else if ((value = getValue(item.replace("W", ""), offset, max)) !== null) {
+      } else if ((value = getValue(item.replace("W", ""), offset, min, max)) !== null) {
         addWeekday(s, curSched, value);
-      } else if ((value = getValue(item.replace("L", ""), offset, max)) !== null) {
+      } else if ((value = getValue(item.replace("L", ""), offset, min, max)) !== null) {
         addHash(schedules, curSched, value, min - 1);
       } else if ((split = item.split("#")).length === 2) {
-        value = getValue(split[0], offset, max);
+        value = getValue(split[0], offset, min, max);
         addHash(schedules, curSched, value, getValue(split[1]));
       } else {
         addRange(item, curSched, name, min, max, offset);

--- a/test/parse/cron-test.js
+++ b/test/parse/cron-test.js
@@ -26,6 +26,11 @@ describe('Parse Cron', function() {
 			p.schedules[0].should.eql({s: [1,5,10]});
 		});
 
+		it('should parse limits', function() {
+			var p = parse('0,59 * * * * *', true);
+			p.schedules[0].should.eql({s: [0,59]});
+		});
+
 		it('should parse unsorted values and sort them', function() {
 			var p = parse('1,10,5 * * * * *', true);
 			p.schedules[0].should.eql({s: [1,5,10]});
@@ -85,6 +90,11 @@ describe('Parse Cron', function() {
 			p.schedules[0].should.eql({m: [1,5,10]});
 		});
 
+		it('should parse limits', function() {
+			var p = parse('* 0,59 * * * *', true);
+			p.schedules[0].should.eql({m: [0,59]});
+		});
+
 		it('should parse a range value', function() {
 			var p = parse('* 1-5 * * * *', true);
 			p.schedules[0].should.eql({m: [1,2,3,4,5]});
@@ -132,6 +142,11 @@ describe('Parse Cron', function() {
 		it('should parse multiple values', function() {
 			var p = parse('* * 1,5,10 * * *', true);
 			p.schedules[0].should.eql({h: [1,5,10]});
+		});
+
+		it('should parse limits', function() {
+			var p = parse('* * 0,23 * * *', true);
+			p.schedules[0].should.eql({h: [0,23]});
 		});
 
 		it('should parse a range value', function() {
@@ -190,6 +205,11 @@ describe('Parse Cron', function() {
 		it('should parse multiple values', function() {
 			var p = parse('* * * 1,5,10 * *', true);
 			p.schedules[0].should.eql({D: [1,5,10]});
+		});
+
+		it('should parse limits', function() {
+			var p = parse('* * * 1,31 * *', true);
+			p.schedules[0].should.eql({D: [1,31]});
 		});
 
 		it('should parse a range value', function() {
@@ -254,6 +274,11 @@ describe('Parse Cron', function() {
 			p.schedules[0].should.eql({M: [1,5,10]});
 		});
 
+		it('should parse limits', function() {
+			var p = parse('* * * * 1,12 *', true);
+			p.schedules[0].should.eql({M: [1,12]});
+		});
+
 		it('should parse a range value', function() {
 			var p = parse('* * * * 1-5 *', true);
 			p.schedules[0].should.eql({M: [1,2,3,4,5]});
@@ -310,7 +335,7 @@ describe('Parse Cron', function() {
 
 		it('should parse 7 as Sunday', function() {
 			var p = parse('* * * * * 7', true);
-			p.schedules[0].should.eql({d: [7]});
+			p.schedules[0].should.eql({d: [1]});
 		});
 
 		it('should parse multiple values', function() {
@@ -318,9 +343,14 @@ describe('Parse Cron', function() {
 			p.schedules[0].should.eql({d: [2,3,6]});
 		});
 
+		it('should parse limits', function() {
+			var p = parse('* * * * * 0,6,7', true);
+			p.schedules[0].should.eql({d: [1,7]});
+		});
+
 		it('should parse multiple values with 7', function() {
 			var p = parse('* * * * * 1,2,5,7', true);
-			p.schedules[0].should.eql({d: [2,3,6,7]});
+			p.schedules[0].should.eql({d: [1,2,3,6]});
 		});
 
 		it('should parse a range value', function() {
@@ -388,7 +418,7 @@ describe('Parse Cron', function() {
 			var p = parse('* * * * * 2,1#2,7#3', true);
 			p.schedules[0].should.eql({d: [3]});
 			p.schedules[1].should.eql({d: [2], dc:[2]});
-			p.schedules[2].should.eql({d: [7], dc:[3]});
+			p.schedules[2].should.eql({d: [1], dc:[3]});
 		});
 
 		it('should parse a single value in words', function() {
@@ -428,6 +458,11 @@ describe('Parse Cron', function() {
 		it('should parse multiple values', function() {
 			var p = parse('* * * * * * 2012,2014,2020', true);
 			p.schedules[0].should.eql({Y: [2012,2014,2020]});
+		});
+
+		it('should parse limits', function() {
+			var p = parse('* * * * * * 1970,2099', true);
+			p.schedules[0].should.eql({Y: [1970,2099]});
 		});
 
 		it('should parse a range value', function() {


### PR DESCRIPTION
This fixes #152 .

The downside of this approach is that the behaviour for illegal values changes.

Previously:
```JavaScript
> later.parse.cron('59 * * * *', null).schedules[0].m
[ 59 ]
> later.parse.cron('60 * * * *', null).schedules[0].m
[ 59 ]
> later.parse.cron('61 * * * *', null).schedules[0].m
[ 59 ]
```

Now:
```JavaScript
> later.parse.cron('59 * * * *', null).schedules[0].m
[ 59 ]
> later.parse.cron('60 * * * *', null).schedules[0].m
[ 0 ]
> later.parse.cron('61 * * * *', null).schedules[0].m
[ 1 ]
```

I'd say this change shouldn't affect anybody because Vixie cron doesn't support these illegal values anyways.
