### PR TITLE
Fix 12am hour text parsing

### DIFF
--- a/later.js
+++ b/later.js
@@ -1528,7 +1528,13 @@ later = function() {
       var output = str;
       switch (tokenType) {
        case TOKENTYPES.time:
-        var parts = str.split(/(:|am|pm)/), hour = parts[3] === "pm" && parts[0] < 12 ? parseInt(parts[0], 10) + 12 : parts[0], min = parts[2].trim();
+        var parts = str.split(/(:|am|pm)/), hour = parseInt(parts[0], 10), min = parts[2].trim();
+        if (parts[3] === "pm" && hour < 12) {
+          hour += 12;
+        } else if (parts[3] === "am" && hour === 12) {
+          hour -= 12;
+        }
+        hour = "" + hour;
         output = (hour.length === 1 ? "0" : "") + hour + ":" + min;
         break;
 

--- a/src/parse/text.js
+++ b/src/parse/text.js
@@ -393,8 +393,16 @@ later.parse.text = function(str) {
     switch (tokenType) {
       case TOKENTYPES.time:
         var parts = str.split(/(:|am|pm)/),
-            hour = parts[3] === 'pm' && parts[0] < 12 ? parseInt(parts[0],10) + 12 : parts[0],
+            hour = parseInt(parts[0],10),
             min = parts[2].trim();
+
+        if (parts[3] === 'pm' && hour < 12) {
+          hour += 12;
+        } else if (parts[3] === 'am' && hour === 12) {
+          hour -= 12;
+        }
+
+        hour = '' + hour;
 
         output = (hour.length === 1 ? '0' : '') + hour + ":" + min;
         break;

--- a/test/parse/text-test.js
+++ b/test/parse/text-test.js
@@ -428,6 +428,18 @@ describe('Parse Text', function() {
 			p.schedules[0].should.have.ownProperty('t');
 			p.schedules[0].t.should.eql([61200]);
 		});
+
+		it('should parse 12 oclock hour in the am', function() {
+			var p = parse('at 12:00 am');
+			p.schedules[0].should.have.ownProperty('t');
+			p.schedules[0].t.should.eql([0]);
+		});
+
+		it('should parse 12 oclock hour in the pm', function() {
+			var p = parse('at 12:00 pm');
+			p.schedules[0].should.have.ownProperty('t');
+			p.schedules[0].t.should.eql([43200]);
+		});
 	});
 
 	describe('on', function() {


### PR DESCRIPTION
I ran into this bug in production when trying to parse `12:01am`. 