### PR TITLE
#155 process is undefined in webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,11 @@ globals.forEach(function(g) {
   if (g in global) globalValues[g] = global[g];
 });
 
-require(process.env['LATER_COV'] ? "./later-cov" : "./later");
+if (process && process.env['LATER_COV']) {
+  require("./later.cov");
+} else {
+  require("./later");
+}
 
 module.exports = later;
 


### PR DESCRIPTION
process is a global nodejs variable that is not defined in the browser by default. So webpack doesn't know about it. Of course there are ways to define the process variable with webpack but that is not the default behavior and needs a plugin (DefinePlugin) or other workaround.
I've tested this change locally with an angular/ionic app and it works great. I also tried to keep the ternary operator (?:) but this also confuses webpack.